### PR TITLE
feat(docs): add sidebar_position to all modules

### DIFF
--- a/adk-training-docs/docs/module01-intro-to-ai-agents/index.md
+++ b/adk-training-docs/docs/module01-intro-to-ai-agents/index.md
@@ -1,5 +1,7 @@
+---
+sidebar_position: 1
+---
 # Module 1: Introduction to AI Agents
-
 ![Introduction to AI Agents](../../../nanobanana-output/a_futuristic_illustration_of_an_.png)
 
 # Module 1: Introduction to AI Agents & Google ADK

--- a/adk-training-docs/docs/module01-intro-to-ai-agents/lab-solution.md
+++ b/adk-training-docs/docs/module01-intro-to-ai-agents/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 1: Introduction to AI Agents & Google ADK
 
 ## Lab 1 Solution: Exploring the ADK Ecosystem

--- a/adk-training-docs/docs/module01-intro-to-ai-agents/lab.md
+++ b/adk-training-docs/docs/module01-intro-to-ai-agents/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 1: Introduction to AI Agents & Google ADK
 
 ## Lab 1: Exploring the ADK Ecosystem

--- a/adk-training-docs/docs/module02-environment-setup/index.md
+++ b/adk-training-docs/docs/module02-environment-setup/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 2: Setting Up Your Development Environment
 
 ## Theory

--- a/adk-training-docs/docs/module02-environment-setup/lab-solution.md
+++ b/adk-training-docs/docs/module02-environment-setup/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 2: Setting Up Your Development Environment
 
 ## Lab 2: Installation and Configuration

--- a/adk-training-docs/docs/module02-environment-setup/lab.md
+++ b/adk-training-docs/docs/module02-environment-setup/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Lab 2: Environment Setup Challenge
 
 ## Goal

--- a/adk-training-docs/docs/module03-first-agent-echo/index.md
+++ b/adk-training-docs/docs/module03-first-agent-echo/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 3: Your First Agent: The "Echo" Agent
 
 ## Theory

--- a/adk-training-docs/docs/module03-first-agent-echo/lab-solution.md
+++ b/adk-training-docs/docs/module03-first-agent-echo/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 3: Your First Agent: The "Echo" Agent
 
 ## Lab 3: Build and Run the "Echo" Agent

--- a/adk-training-docs/docs/module03-first-agent-echo/lab.md
+++ b/adk-training-docs/docs/module03-first-agent-echo/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Lab 3: Build and Run the "Echo" Agent Challenge
 
 ## Goal

--- a/adk-training-docs/docs/module04-llmagent-deep-dive/index.md
+++ b/adk-training-docs/docs/module04-llmagent-deep-dive/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 4: Core Agent Concepts: `LlmAgent` Deep Dive
 
 ## Theory

--- a/adk-training-docs/docs/module04-llmagent-deep-dive/lab-solution.md
+++ b/adk-training-docs/docs/module04-llmagent-deep-dive/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 4: Core Agent Concepts: `LlmAgent` Deep Dive
 
 ## Lab 4: Transforming the "Echo" Agent with Instructions

--- a/adk-training-docs/docs/module04-llmagent-deep-dive/lab.md
+++ b/adk-training-docs/docs/module04-llmagent-deep-dive/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Lab 4: Transforming the "Echo" Agent Challenge
 
 ## Goal

--- a/adk-training-docs/docs/module05-running-agents/index.md
+++ b/adk-training-docs/docs/module05-running-agents/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 5: Running and Interacting with Agents
 
 ## Theory

--- a/adk-training-docs/docs/module05-running-agents/lab-solution.md
+++ b/adk-training-docs/docs/module05-running-agents/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 5: Running and Interacting with Agents
 
 ## Lab 5: Exploring Different Execution Modes

--- a/adk-training-docs/docs/module05-running-agents/lab.md
+++ b/adk-training-docs/docs/module05-running-agents/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Lab 5: Exploring Different Execution Modes Challenge
 
 ## Goal

--- a/adk-training-docs/docs/module06-programmatic-execution/index.md
+++ b/adk-training-docs/docs/module06-programmatic-execution/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 6: Running an Agent Programmatically
 
 ## Theory

--- a/adk-training-docs/docs/module06-programmatic-execution/lab-solution.md
+++ b/adk-training-docs/docs/module06-programmatic-execution/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 6: Running an Agent Programmatically
 
 ## Lab 6: Solution

--- a/adk-training-docs/docs/module06-programmatic-execution/lab.md
+++ b/adk-training-docs/docs/module06-programmatic-execution/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 6: Running an Agent Programmatically
 
 ## Lab 6: Executing Your Agent in a Python Script

--- a/adk-training-docs/docs/module07-multimodal-and-images/index.md
+++ b/adk-training-docs/docs/module07-multimodal-and-images/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 7: Multimodal and Image Processing
 
 ## Theory

--- a/adk-training-docs/docs/module07-multimodal-and-images/lab-solution.md
+++ b/adk-training-docs/docs/module07-multimodal-and-images/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 7: Multimodal and Image Processing
 
 ## Lab 39: Solution

--- a/adk-training-docs/docs/module07-multimodal-and-images/lab.md
+++ b/adk-training-docs/docs/module07-multimodal-and-images/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 7: Multimodal and Image Processing
 
 ## Lab 39: Building a Visual Product Catalog Analyzer

--- a/adk-training-docs/docs/module08-intro-to-tools/index.md
+++ b/adk-training-docs/docs/module08-intro-to-tools/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 8: Introduction to Tools
 
 ## Theory

--- a/adk-training-docs/docs/module08-intro-to-tools/lab-solution.md
+++ b/adk-training-docs/docs/module08-intro-to-tools/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 7: Introduction to Tools
 
 ## Lab 7: Solution

--- a/adk-training-docs/docs/module08-intro-to-tools/lab.md
+++ b/adk-training-docs/docs/module08-intro-to-tools/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 6: Introduction to Tools
 
 ## Lab 6: Creating a "Researcher" Agent with Google Search

--- a/adk-training-docs/docs/module09-intro-custom-function-tools/index.md
+++ b/adk-training-docs/docs/module09-intro-custom-function-tools/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 9: Creating Custom Function Tools
 
 ## Theory

--- a/adk-training-docs/docs/module09-intro-custom-function-tools/lab-solution.md
+++ b/adk-training-docs/docs/module09-intro-custom-function-tools/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 8: Creating Custom Function Tools
 
 ## Lab 8: Solution

--- a/adk-training-docs/docs/module09-intro-custom-function-tools/lab.md
+++ b/adk-training-docs/docs/module09-intro-custom-function-tools/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 8: Creating Custom Function Tools
 
 ## Lab 8: Building a "Calculator" Agent

--- a/adk-training-docs/docs/module10-advanced-function-tools/index.md
+++ b/adk-training-docs/docs/module10-advanced-function-tools/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 10: Advanced Function Tools
 
 ## Theory

--- a/adk-training-docs/docs/module10-advanced-function-tools/lab-solution.md
+++ b/adk-training-docs/docs/module10-advanced-function-tools/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 9: Advanced Function Tools
 
 ## Lab 9: Solution

--- a/adk-training-docs/docs/module10-advanced-function-tools/lab.md
+++ b/adk-training-docs/docs/module10-advanced-function-tools/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 9: Advanced Function Tools
 
 ## Lab 9: Building a Personal Finance Assistant

--- a/adk-training-docs/docs/module11-openapi-tools/index.md
+++ b/adk-training-docs/docs/module11-openapi-tools/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 11: OpenAPI Tools
 
 ## Theory

--- a/adk-training-docs/docs/module11-openapi-tools/lab-solution.md
+++ b/adk-training-docs/docs/module11-openapi-tools/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 10: OpenAPI Tools
 
 ## Lab 10: Solution

--- a/adk-training-docs/docs/module11-openapi-tools/lab.md
+++ b/adk-training-docs/docs/module11-openapi-tools/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 10: OpenAPI Tools
 
 ## Lab 10: Building a Chuck Norris Fact Assistant

--- a/adk-training-docs/docs/module12-built-in-tools-grounding/index.md
+++ b/adk-training-docs/docs/module12-built-in-tools-grounding/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 12: Built-in Tools and Grounding
 
 ## Theory

--- a/adk-training-docs/docs/module12-built-in-tools-grounding/lab-solution.md
+++ b/adk-training-docs/docs/module12-built-in-tools-grounding/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 11: Built-in Tools and Grounding
 
 ## Lab 11: Solution

--- a/adk-training-docs/docs/module12-built-in-tools-grounding/lab.md
+++ b/adk-training-docs/docs/module12-built-in-tools-grounding/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 11: Built-in Tools and Grounding
 
 ## Lab 11: Building a Research Assistant with Web Search

--- a/adk-training-docs/docs/module13-tool-context/index.md
+++ b/adk-training-docs/docs/module13-tool-context/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 13: Advanced Tool Concepts: Tool Context
 
 ## Theory

--- a/adk-training-docs/docs/module13-tool-context/lab-solution.md
+++ b/adk-training-docs/docs/module13-tool-context/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 12: Advanced Tool Concepts: Tool Context
 
 ## Lab 12: Solution

--- a/adk-training-docs/docs/module13-tool-context/lab.md
+++ b/adk-training-docs/docs/module13-tool-context/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 12: Advanced Tool Concepts: Tool Context
 
 ## Lab 12: Creating a "Memory" Agent with Tool Context

--- a/adk-training-docs/docs/module14-third-party-tools/index.md
+++ b/adk-training-docs/docs/module14-third-party-tools/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 14: Integrating Third-Party Tools
 
 ## Theory

--- a/adk-training-docs/docs/module14-third-party-tools/lab-solution.md
+++ b/adk-training-docs/docs/module14-third-party-tools/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 13: Integrating Third-Party Tools
 
 ## Lab 13: Solution

--- a/adk-training-docs/docs/module14-third-party-tools/lab.md
+++ b/adk-training-docs/docs/module14-third-party-tools/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 13: Integrating Third-Party Tools
 
 ## Lab 13: Integrating a LangChain Wikipedia Tool

--- a/adk-training-docs/docs/module15-intro-to-multi-agent-systems/index.md
+++ b/adk-training-docs/docs/module15-intro-to-multi-agent-systems/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 15: Introduction to Multi-Agent Systems
 
 ## Theory

--- a/adk-training-docs/docs/module15-intro-to-multi-agent-systems/lab-solution.md
+++ b/adk-training-docs/docs/module15-intro-to-multi-agent-systems/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 14: Introduction to Multi-Agent Systems
 
 ## Lab 14: Solution

--- a/adk-training-docs/docs/module15-intro-to-multi-agent-systems/lab.md
+++ b/adk-training-docs/docs/module15-intro-to-multi-agent-systems/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 14: Introduction to Multi-Agent Systems
 
 ## Lab 14: Designing a Multi-Agent System

--- a/adk-training-docs/docs/module16-coordinator-agent/index.md
+++ b/adk-training-docs/docs/module16-coordinator-agent/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 16: Building a Coordinator/Dispatcher Agent
 
 ## Theory

--- a/adk-training-docs/docs/module16-coordinator-agent/lab-solution.md
+++ b/adk-training-docs/docs/module16-coordinator-agent/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 15: Building a Coordinator/Dispatcher Agent
 
 ## Lab 15: Solution

--- a/adk-training-docs/docs/module16-coordinator-agent/lab.md
+++ b/adk-training-docs/docs/module16-coordinator-agent/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 15: Building a Coordinator/Dispatcher Agent
 
 ## Lab 15: Implementing the "Greeting Router"

--- a/adk-training-docs/docs/module17-sequential-workflow-agents/index.md
+++ b/adk-training-docs/docs/module17-sequential-workflow-agents/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 17: Sequential Workflows - Building Agent Pipelines
 
 ## Theory

--- a/adk-training-docs/docs/module17-sequential-workflow-agents/lab-solution.md
+++ b/adk-training-docs/docs/module17-sequential-workflow-agents/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 16: Building Agent Pipelines with SequentialAgent
 
 ## Lab 16: Solution

--- a/adk-training-docs/docs/module17-sequential-workflow-agents/lab.md
+++ b/adk-training-docs/docs/module17-sequential-workflow-agents/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 16: Building Agent Pipelines with SequentialAgent
 
 ## Lab 16: Building a Blog Post Generator Pipeline

--- a/adk-training-docs/docs/module18-parallel-workflow-agents/index.md
+++ b/adk-training-docs/docs/module18-parallel-workflow-agents/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 18: Parallel Processing with ParallelAgent
 
 ## Theory

--- a/adk-training-docs/docs/module18-parallel-workflow-agents/lab-solution.md
+++ b/adk-training-docs/docs/module18-parallel-workflow-agents/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 17: Parallel Processing with ParallelAgent
 
 ## Lab 17: Solution

--- a/adk-training-docs/docs/module18-parallel-workflow-agents/lab.md
+++ b/adk-training-docs/docs/module18-parallel-workflow-agents/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 17: Parallel Processing with ParallelAgent
 
 ## Lab 17: Building a Smart Travel Planner

--- a/adk-training-docs/docs/module19-advanced-multi-agent-architectures/index.md
+++ b/adk-training-docs/docs/module19-advanced-multi-agent-architectures/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 19: Advanced Multi-Agent Architectures
 
 ## Theory

--- a/adk-training-docs/docs/module19-advanced-multi-agent-architectures/lab-solution.md
+++ b/adk-training-docs/docs/module19-advanced-multi-agent-architectures/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 17: Multi-Agent Systems - Complex Orchestration
 
 ## Lab 17: Solution

--- a/adk-training-docs/docs/module19-advanced-multi-agent-architectures/lab.md
+++ b/adk-training-docs/docs/module19-advanced-multi-agent-architectures/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 18: Advanced Multi-Agent Architectures
 
 ## Lab 18: Building a Content Publishing System

--- a/adk-training-docs/docs/module20-loop-agents/index.md
+++ b/adk-training-docs/docs/module20-loop-agents/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 20: Iterative Refinement with Loop Agents
 
 ## Theory

--- a/adk-training-docs/docs/module20-loop-agents/lab-solution.md
+++ b/adk-training-docs/docs/module20-loop-agents/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 19: Iterative Refinement with Loop Agents
 
 ## Lab 19: Solution

--- a/adk-training-docs/docs/module20-loop-agents/lab.md
+++ b/adk-training-docs/docs/module20-loop-agents/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 19: Iterative Refinement with Loop Agents
 
 ## Lab 19: Building an Essay Refinement System

--- a/adk-training-docs/docs/module21-agent-to-agent/index.md
+++ b/adk-training-docs/docs/module21-agent-to-agent/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 21: Agent-to-Agent Communication
 
 ## Theory

--- a/adk-training-docs/docs/module21-agent-to-agent/lab-solution.md
+++ b/adk-training-docs/docs/module21-agent-to-agent/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 35: Agent-to-Agent Communication
 
 ## Lab 35: Solution

--- a/adk-training-docs/docs/module21-agent-to-agent/lab.md
+++ b/adk-training-docs/docs/module21-agent-to-agent/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 35: Agent-to-Agent Communication
 
 ## Lab 35: Building a Distributed Research System

--- a/adk-training-docs/docs/module22-state-and-memory/index.md
+++ b/adk-training-docs/docs/module22-state-and-memory/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 20: State and Memory - Persistent Agent Context
 
 ## Theory

--- a/adk-training-docs/docs/module22-state-and-memory/lab-solution.md
+++ b/adk-training-docs/docs/module22-state-and-memory/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 20: State and Memory - Building a Personal Tutor Agent
 
 ## Lab 20: Solution

--- a/adk-training-docs/docs/module22-state-and-memory/lab.md
+++ b/adk-training-docs/docs/module22-state-and-memory/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 20: State and Memory - Building a Personal Tutor Agent
 
 ## Lab 20: Building a Personal Learning Tutor

--- a/adk-training-docs/docs/module23-artifacts/index.md
+++ b/adk-training-docs/docs/module23-artifacts/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 21: Handling Files with Artifacts
 
 ## Theory

--- a/adk-training-docs/docs/module23-artifacts/lab-solution.md
+++ b/adk-training-docs/docs/module23-artifacts/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 21: Handling Files with Artifacts
 
 ## Lab 21: Solution

--- a/adk-training-docs/docs/module23-artifacts/lab.md
+++ b/adk-training-docs/docs/module23-artifacts/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 21: Handling Files with Artifacts
 
 ## Lab 21: Building a Document Processing Pipeline

--- a/adk-training-docs/docs/module24-evaluation/index.md
+++ b/adk-training-docs/docs/module24-evaluation/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 24: Evaluating Agent Performance
 
 ## Theory

--- a/adk-training-docs/docs/module24-evaluation/lab-solution.md
+++ b/adk-training-docs/docs/module24-evaluation/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 23: Evaluating Agent Performance
 
 ## Lab 23: Solution

--- a/adk-training-docs/docs/module24-evaluation/lab.md
+++ b/adk-training-docs/docs/module24-evaluation/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 24: Evaluating Agent Performance
 
 ## Lab 17: Creating an Evaluation Case for the Calculator Agent

--- a/adk-training-docs/docs/module25-observability/index.md
+++ b/adk-training-docs/docs/module25-observability/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 25: Advanced Observability with Plugins
 
 ## Theory

--- a/adk-training-docs/docs/module25-observability/lab-solution.md
+++ b/adk-training-docs/docs/module25-observability/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 27: Advanced Observability with Plugins
 
 ## Lab 27: Solution

--- a/adk-training-docs/docs/module25-observability/lab.md
+++ b/adk-training-docs/docs/module25-observability/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 27: Advanced Observability with Plugins
 
 ## Lab 27: Building an Observability System with Plugins

--- a/adk-training-docs/docs/module26-callbacks/index.md
+++ b/adk-training-docs/docs/module26-callbacks/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 26: Callbacks and Guardrails - Agent Safety and Monitoring
 
 ## Theory

--- a/adk-training-docs/docs/module26-callbacks/lab-solution.md
+++ b/adk-training-docs/docs/module26-callbacks/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 26: Callbacks and Guardrails - Building a Content Moderator
 
 ## Lab 26: Solution

--- a/adk-training-docs/docs/module26-callbacks/lab.md
+++ b/adk-training-docs/docs/module26-callbacks/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 28: Callbacks and Guardrails - Building a Content Moderator
 
 ## Lab 28: Building a Content Moderation Assistant

--- a/adk-training-docs/docs/module27-intro-to-mcp/index.md
+++ b/adk-training-docs/docs/module27-intro-to-mcp/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 27: Introduction to MCP & Stateful Tools
 
 ## Theory

--- a/adk-training-docs/docs/module27-intro-to-mcp/lab-solution.md
+++ b/adk-training-docs/docs/module27-intro-to-mcp/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 29: Introduction to MCP & Stateful Tools
 
 ## Lab 29: Solution

--- a/adk-training-docs/docs/module27-intro-to-mcp/lab.md
+++ b/adk-training-docs/docs/module27-intro-to-mcp/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 29: Introduction to MCP & Stateful Tools
 
 ## Lab 29: Using a Stateful File System Tool

--- a/adk-training-docs/docs/module28-building-mcp-tools/index.md
+++ b/adk-training-docs/docs/module28-building-mcp-tools/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 28: Building a Custom MCP Tool
 
 ## Theory

--- a/adk-training-docs/docs/module28-building-mcp-tools/lab-solution.md
+++ b/adk-training-docs/docs/module28-building-mcp-tools/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 30: Building a Custom MCP Tool
 
 ## Lab 30: Solution

--- a/adk-training-docs/docs/module28-building-mcp-tools/lab.md
+++ b/adk-training-docs/docs/module28-building-mcp-tools/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 30: Building a Custom MCP Tool
 
 ## Lab 30: Building a "Shopping Cart" MCP Server

--- a/adk-training-docs/docs/module29-ui-integration-intro/index.md
+++ b/adk-training-docs/docs/module29-ui-integration-intro/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 29: Introduction to UI Integration
 
 ## Theory

--- a/adk-training-docs/docs/module29-ui-integration-intro/lab-solution.md
+++ b/adk-training-docs/docs/module29-ui-integration-intro/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 38: Introduction to UI Integration
 
 ## Lab 38: Solution

--- a/adk-training-docs/docs/module29-ui-integration-intro/lab.md
+++ b/adk-training-docs/docs/module29-ui-integration-intro/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 38: Introduction to UI Integration
 
 ## Lab 38: Building a Simple Custom Chat UI

--- a/adk-training-docs/docs/module30-custom-streaming-client/index.md
+++ b/adk-training-docs/docs/module30-custom-streaming-client/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 30: Building a Custom Streaming Client
 
 ## Theory

--- a/adk-training-docs/docs/module30-custom-streaming-client/lab-solution.md
+++ b/adk-training-docs/docs/module30-custom-streaming-client/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 32: Building a Custom Streaming Client
 
 ## Lab 32: Solution

--- a/adk-training-docs/docs/module30-custom-streaming-client/lab.md
+++ b/adk-training-docs/docs/module30-custom-streaming-client/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 32: Building a Custom Streaming Client
 
 ## Lab 32: Interacting with a Custom Voice Client

--- a/adk-training-docs/docs/module31-production-deployment-strategies/index.md
+++ b/adk-training-docs/docs/module31-production-deployment-strategies/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 31: Production Deployment Strategies
 
 ## Theory

--- a/adk-training-docs/docs/module31-production-deployment-strategies/lab-solution.md
+++ b/adk-training-docs/docs/module31-production-deployment-strategies/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 24: Production Deployment Strategies
 
 ## Lab 24: Solution

--- a/adk-training-docs/docs/module31-production-deployment-strategies/lab.md
+++ b/adk-training-docs/docs/module31-production-deployment-strategies/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 24: Production Deployment Strategies
 
 ## Lab 24: Choosing the Right Deployment Strategy

--- a/adk-training-docs/docs/module32-deployment-cloud-run/index.md
+++ b/adk-training-docs/docs/module32-deployment-cloud-run/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 32: Deployment to Cloud Run
 
 ## Theory

--- a/adk-training-docs/docs/module32-deployment-cloud-run/lab-solution.md
+++ b/adk-training-docs/docs/module32-deployment-cloud-run/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 25: Deployment to Cloud Run
 
 ## Lab 25: Solution

--- a/adk-training-docs/docs/module32-deployment-cloud-run/lab.md
+++ b/adk-training-docs/docs/module32-deployment-cloud-run/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 25: Deployment to Cloud Run
 
 ## Lab 25: Deploying the Customer Support Agent

--- a/adk-training-docs/docs/module33-deployment-gke/index.md
+++ b/adk-training-docs/docs/module33-deployment-gke/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 33: Deployment to Google Kubernetes Engine (GKE)
 
 ## Theory

--- a/adk-training-docs/docs/module33-deployment-gke/lab-solution.md
+++ b/adk-training-docs/docs/module33-deployment-gke/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 26: Deployment to Google Kubernetes Engine (GKE)
 
 ## Lab 26: Solution

--- a/adk-training-docs/docs/module33-deployment-gke/lab.md
+++ b/adk-training-docs/docs/module33-deployment-gke/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 26: Deployment to Google Kubernetes Engine (GKE)
 
 ## Lab 26: Manually Deploying an Agent to GKE

--- a/adk-training-docs/docs/module34-deploying-mcp-server-cloud-run/index.md
+++ b/adk-training-docs/docs/module34-deploying-mcp-server-cloud-run/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 34: Deploying an MCP Server to Cloud Run
 
 ## Theory

--- a/adk-training-docs/docs/module34-deploying-mcp-server-cloud-run/lab-solution.md
+++ b/adk-training-docs/docs/module34-deploying-mcp-server-cloud-run/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 31: Deploying an MCP Server to Cloud Run
 
 ## Lab 31: Solution

--- a/adk-training-docs/docs/module34-deploying-mcp-server-cloud-run/lab.md
+++ b/adk-training-docs/docs/module34-deploying-mcp-server-cloud-run/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 31: Deploying an MCP Server to Cloud Run
 
 ## Lab 31: Deploying the "Shopping Cart" Server

--- a/adk-training-docs/docs/module35-deployment-agent-engine/index.md
+++ b/adk-training-docs/docs/module35-deployment-agent-engine/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 35: Deploying to Agent Engine
 
 ## Theory

--- a/adk-training-docs/docs/module35-deployment-agent-engine/lab-solution.md
+++ b/adk-training-docs/docs/module35-deployment-agent-engine/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 34: Deploying to Agent Engine
 
 ## Lab 34: Solution

--- a/adk-training-docs/docs/module35-deployment-agent-engine/lab.md
+++ b/adk-training-docs/docs/module35-deployment-agent-engine/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 34: Deploying to Agent Engine
 
 ## Lab 34: Deploying the Calculator Agent

--- a/adk-training-docs/docs/module36-gemini-enterprise/index.md
+++ b/adk-training-docs/docs/module36-gemini-enterprise/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 36: Gemini Enterprise (formerly AgentSpace)
 
 ## Theory

--- a/adk-training-docs/docs/module36-gemini-enterprise/lab-solution.md
+++ b/adk-training-docs/docs/module36-gemini-enterprise/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 37: Gemini Enterprise
 
 ## Lab 37: Solution

--- a/adk-training-docs/docs/module36-gemini-enterprise/lab.md
+++ b/adk-training-docs/docs/module36-gemini-enterprise/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 37: Gemini Enterprise
 
 ## Lab 37: Designing an Enterprise Agent Strategy

--- a/adk-training-docs/docs/module37-advanced-personalized-shopping-agent/index.md
+++ b/adk-training-docs/docs/module37-advanced-personalized-shopping-agent/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 37: Advanced - Building a Personalized Shopping Agent
 
 ## Theory

--- a/adk-training-docs/docs/module37-advanced-personalized-shopping-agent/lab-solution.md
+++ b/adk-training-docs/docs/module37-advanced-personalized-shopping-agent/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 37: Advanced - Building a Personalized Shopping Agent
 
 ## Challenging Lab - Solution

--- a/adk-training-docs/docs/module37-advanced-personalized-shopping-agent/lab.md
+++ b/adk-training-docs/docs/module37-advanced-personalized-shopping-agent/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 37: Advanced - Building a Personalized Shopping Agent
 
 ## Challenging Lab: Building a Distributed Multi-Agent System

--- a/adk-training-docs/docs/module38-best-practices/index.md
+++ b/adk-training-docs/docs/module38-best-practices/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 1
+---
 # Module 38: Best Practices & Production Patterns
 
 ## Theory

--- a/adk-training-docs/docs/module38-best-practices/lab-solution.md
+++ b/adk-training-docs/docs/module38-best-practices/lab-solution.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Module 36: Best Practices & Production Patterns
 
 ## Lab 36: Solution

--- a/adk-training-docs/docs/module38-best-practices/lab.md
+++ b/adk-training-docs/docs/module38-best-practices/lab.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Module 36: Best Practices & Production Patterns
 
 ## Lab 36: Building a Production-Ready Agent


### PR DESCRIPTION
This commit adds the 'sidebar_position' front matter to the index.md, lab.md, and lab-solution.md files for all modules from 2 to 38. This ensures that the pages within each module's category are displayed in the correct logical order (Theory -> Lab -> Solution) in the Docusaurus sidebar.