### PR TITLE
fix(docs): restore missing front matter to lab files

### DIFF
--- a/adk-training-docs/docs/module01-intro-to-ai-agents/lab-solution.md
+++ b/adk-training-docs/docs/module01-intro-to-ai-agents/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 1: Introduction to AI Agents & Google ADK
 
 # Lab 1: Solution

--- a/adk-training-docs/docs/module01-intro-to-ai-agents/lab.md
+++ b/adk-training-docs/docs/module01-intro-to-ai-agents/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 1: Introduction to AI Agents & Google ADK

--- a/adk-training-docs/docs/module02-environment-setup/lab-solution.md
+++ b/adk-training-docs/docs/module02-environment-setup/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 2: Setting Up Your Development Environment
 
 # Lab 2: Exercise

--- a/adk-training-docs/docs/module02-environment-setup/lab.md
+++ b/adk-training-docs/docs/module02-environment-setup/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Lab 2: Environment Setup Challenge

--- a/adk-training-docs/docs/module03-first-agent-echo/lab-solution.md
+++ b/adk-training-docs/docs/module03-first-agent-echo/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 3: Your First Agent: The "Echo" Agent
 
 # Lab 3: Exercise

--- a/adk-training-docs/docs/module03-first-agent-echo/lab.md
+++ b/adk-training-docs/docs/module03-first-agent-echo/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Lab 3: Build and Run the "Echo" Agent Challenge

--- a/adk-training-docs/docs/module04-llmagent-deep-dive/lab-solution.md
+++ b/adk-training-docs/docs/module04-llmagent-deep-dive/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 4: Core Agent Concepts: `LlmAgent` Deep Dive
 
 # Lab 4: Exercise

--- a/adk-training-docs/docs/module04-llmagent-deep-dive/lab.md
+++ b/adk-training-docs/docs/module04-llmagent-deep-dive/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Lab 4: Transforming the "Echo" Agent Challenge

--- a/adk-training-docs/docs/module05-running-agents/lab-solution.md
+++ b/adk-training-docs/docs/module05-running-agents/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 5: Running and Interacting with Agents
 
 # Lab 5: Exploring Different Execution Modes

--- a/adk-training-docs/docs/module05-running-agents/lab.md
+++ b/adk-training-docs/docs/module05-running-agents/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Lab 5: Exploring Different Execution Modes Challenge

--- a/adk-training-docs/docs/module06-programmatic-execution/lab-solution.md
+++ b/adk-training-docs/docs/module06-programmatic-execution/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 6: Running an Agent Programmatically
 
 # Lab 6: Solution

--- a/adk-training-docs/docs/module06-programmatic-execution/lab.md
+++ b/adk-training-docs/docs/module06-programmatic-execution/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 6: Running an Agent Programmatically

--- a/adk-training-docs/docs/module07-multimodal-and-images/lab-solution.md
+++ b/adk-training-docs/docs/module07-multimodal-and-images/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 7: Multimodal and Image Processing
 
 # Lab 7: Solution

--- a/adk-training-docs/docs/module07-multimodal-and-images/lab.md
+++ b/adk-training-docs/docs/module07-multimodal-and-images/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 7: Multimodal and Image Processing

--- a/adk-training-docs/docs/module08-intro-to-tools/lab-solution.md
+++ b/adk-training-docs/docs/module08-intro-to-tools/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 7: Introduction to Tools
 
 # Lab 8: Solution

--- a/adk-training-docs/docs/module08-intro-to-tools/lab.md
+++ b/adk-training-docs/docs/module08-intro-to-tools/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 6: Introduction to Tools

--- a/adk-training-docs/docs/module09-intro-custom-function-tools/lab-solution.md
+++ b/adk-training-docs/docs/module09-intro-custom-function-tools/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 8: Creating Custom Function Tools
 
 # Lab 9: Solution

--- a/adk-training-docs/docs/module09-intro-custom-function-tools/lab.md
+++ b/adk-training-docs/docs/module09-intro-custom-function-tools/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 8: Creating Custom Function Tools

--- a/adk-training-docs/docs/module10-advanced-function-tools/lab-solution.md
+++ b/adk-training-docs/docs/module10-advanced-function-tools/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 9: Advanced Function Tools
 
 # Lab 10: Solution

--- a/adk-training-docs/docs/module10-advanced-function-tools/lab.md
+++ b/adk-training-docs/docs/module10-advanced-function-tools/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 9: Advanced Function Tools

--- a/adk-training-docs/docs/module11-openapi-tools/lab-solution.md
+++ b/adk-training-docs/docs/module11-openapi-tools/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 10: OpenAPI Tools
 
 # Lab 11: Solution

--- a/adk-training-docs/docs/module11-openapi-tools/lab.md
+++ b/adk-training-docs/docs/module11-openapi-tools/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 10: OpenAPI Tools

--- a/adk-training-docs/docs/module12-built-in-tools-grounding/lab-solution.md
+++ b/adk-training-docs/docs/module12-built-in-tools-grounding/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 11: Built-in Tools and Grounding
 
 # Lab 12: Solution

--- a/adk-training-docs/docs/module12-built-in-tools-grounding/lab.md
+++ b/adk-training-docs/docs/module12-built-in-tools-grounding/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 11: Built-in Tools and Grounding

--- a/adk-training-docs/docs/module13-tool-context/lab-solution.md
+++ b/adk-training-docs/docs/module13-tool-context/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 12: Advanced Tool Concepts: Tool Context
 
 # Lab 13: Solution

--- a/adk-training-docs/docs/module13-tool-context/lab.md
+++ b/adk-training-docs/docs/module13-tool-context/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 12: Advanced Tool Concepts: Tool Context

--- a/adk-training-docs/docs/module14-third-party-tools/lab-solution.md
+++ b/adk-training-docs/docs/module14-third-party-tools/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 13: Integrating Third-Party Tools
 
 # Lab 14: Solution

--- a/adk-training-docs/docs/module14-third-party-tools/lab.md
+++ b/adk-training-docs/docs/module14-third-party-tools/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 13: Integrating Third-Party Tools

--- a/adk-training-docs/docs/module15-intro-to-multi-agent-systems/lab-solution.md
+++ b/adk-training-docs/docs/module15-intro-to-multi-agent-systems/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 14: Introduction to Multi-Agent Systems
 
 # Lab 15: Solution

--- a/adk-training-docs/docs/module15-intro-to-multi-agent-systems/lab.md
+++ b/adk-training-docs/docs/module15-intro-to-multi-agent-systems/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 14: Introduction to Multi-Agent Systems

--- a/adk-training-docs/docs/module16-coordinator-agent/lab-solution.md
+++ b/adk-training-docs/docs/module16-coordinator-agent/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 15: Building a Coordinator/Dispatcher Agent
 
 # Lab 16: Solution

--- a/adk-training-docs/docs/module16-coordinator-agent/lab.md
+++ b/adk-training-docs/docs/module16-coordinator-agent/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 15: Building a Coordinator/Dispatcher Agent

--- a/adk-training-docs/docs/module17-sequential-workflow-agents/lab-solution.md
+++ b/adk-training-docs/docs/module17-sequential-workflow-agents/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 16: Building Agent Pipelines with SequentialAgent
 
 # Lab 17: Solution

--- a/adk-training-docs/docs/module17-sequential-workflow-agents/lab.md
+++ b/adk-training-docs/docs/module17-sequential-workflow-agents/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 16: Building Agent Pipelines with SequentialAgent

--- a/adk-training-docs/docs/module18-parallel-workflow-agents/lab-solution.md
+++ b/adk-training-docs/docs/module18-parallel-workflow-agents/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 17: Parallel Processing with ParallelAgent
 
 # Lab 18: Solution

--- a/adk-training-docs/docs/module18-parallel-workflow-agents/lab.md
+++ b/adk-training-docs/docs/module18-parallel-workflow-agents/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 17: Parallel Processing with ParallelAgent

--- a/adk-training-docs/docs/module19-advanced-multi-agent-architectures/lab-solution.md
+++ b/adk-training-docs/docs/module19-advanced-multi-agent-architectures/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 17: Multi-Agent Systems - Complex Orchestration
 
 # Lab 19: Solution

--- a/adk-training-docs/docs/module19-advanced-multi-agent-architectures/lab.md
+++ b/adk-training-docs/docs/module19-advanced-multi-agent-architectures/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 18: Advanced Multi-Agent Architectures

--- a/adk-training-docs/docs/module20-loop-agents/lab-solution.md
+++ b/adk-training-docs/docs/module20-loop-agents/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 19: Iterative Refinement with Loop Agents
 
 # Lab 20: Solution

--- a/adk-training-docs/docs/module20-loop-agents/lab.md
+++ b/adk-training-docs/docs/module20-loop-agents/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 19: Iterative Refinement with Loop Agents

--- a/adk-training-docs/docs/module21-agent-to-agent/lab-solution.md
+++ b/adk-training-docs/docs/module21-agent-to-agent/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 35: Agent-to-Agent Communication
 
 # Lab 21: Solution

--- a/adk-training-docs/docs/module21-agent-to-agent/lab.md
+++ b/adk-training-docs/docs/module21-agent-to-agent/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 35: Agent-to-Agent Communication

--- a/adk-training-docs/docs/module22-state-and-memory/lab-solution.md
+++ b/adk-training-docs/docs/module22-state-and-memory/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 20: State and Memory - Building a Personal Tutor Agent
 
 # Lab 22: Solution

--- a/adk-training-docs/docs/module22-state-and-memory/lab.md
+++ b/adk-training-docs/docs/module22-state-and-memory/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 20: State and Memory - Building a Personal Tutor Agent

--- a/adk-training-docs/docs/module23-artifacts/lab-solution.md
+++ b/adk-training-docs/docs/module23-artifacts/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 21: Handling Files with Artifacts
 
 # Lab 23: Solution

--- a/adk-training-docs/docs/module23-artifacts/lab.md
+++ b/adk-training-docs/docs/module23-artifacts/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 21: Handling Files with Artifacts

--- a/adk-training-docs/docs/module24-evaluation/lab-solution.md
+++ b/adk-training-docs/docs/module24-evaluation/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 23: Evaluating Agent Performance
 
 # Lab 24: Solution

--- a/adk-training-docs/docs/module24-evaluation/lab.md
+++ b/adk-training-docs/docs/module24-evaluation/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 24: Evaluating Agent Performance

--- a/adk-training-docs/docs/module25-observability/lab-solution.md
+++ b/adk-training-docs/docs/module25-observability/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 27: Advanced Observability with Plugins
 
 # Lab 25: Solution

--- a/adk-training-docs/docs/module25-observability/lab.md
+++ b/adk-training-docs/docs/module25-observability/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 27: Advanced Observability with Plugins

--- a/adk-training-docs/docs/module26-callbacks/lab-solution.md
+++ b/adk-training-docs/docs/module26-callbacks/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 26: Callbacks and Guardrails - Building a Content Moderator
 
 # Lab 26: Solution

--- a/adk-training-docs/docs/module26-callbacks/lab.md
+++ b/adk-training-docs/docs/module26-callbacks/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 28: Callbacks and Guardrails - Building a Content Moderator

--- a/adk-training-docs/docs/module27-intro-to-mcp/lab-solution.md
+++ b/adk-training-docs/docs/module27-intro-to-mcp/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 29: Introduction to MCP & Stateful Tools
 
 # Lab 27: Solution

--- a/adk-training-docs/docs/module27-intro-to-mcp/lab.md
+++ b/adk-training-docs/docs/module27-intro-to-mcp/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 29: Introduction to MCP & Stateful Tools

--- a/adk-training-docs/docs/module28-building-mcp-tools/lab-solution.md
+++ b/adk-training-docs/docs/module28-building-mcp-tools/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 ## Module 28: Building a Custom MCP Tool
 
 # Lab 28: Solution

--- a/adk-training-docs/docs/module28-building-mcp-tools/lab.md
+++ b/adk-training-docs/docs/module28-building-mcp-tools/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 30: Building a Custom MCP Tool

--- a/adk-training-docs/docs/module29-ui-integration-intro/lab-solution.md
+++ b/adk-training-docs/docs/module29-ui-integration-intro/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 ## Module 29: Introduction to UI Integration
 
 # Lab 29: Solution

--- a/adk-training-docs/docs/module29-ui-integration-intro/lab.md
+++ b/adk-training-docs/docs/module29-ui-integration-intro/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 38: Introduction to UI Integration

--- a/adk-training-docs/docs/module30-custom-streaming-client/lab-solution.md
+++ b/adk-training-docs/docs/module30-custom-streaming-client/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 ## Module 30: Building a Custom Streaming Client
 
 # Lab 30: Solution

--- a/adk-training-docs/docs/module30-custom-streaming-client/lab.md
+++ b/adk-training-docs/docs/module30-custom-streaming-client/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 32: Building a Custom Streaming Client

--- a/adk-training-docs/docs/module31-production-deployment-strategies/lab-solution.md
+++ b/adk-training-docs/docs/module31-production-deployment-strategies/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 ## Module 31: Production Deployment Strategies
 
 # Lab 31: Solution

--- a/adk-training-docs/docs/module31-production-deployment-strategies/lab.md
+++ b/adk-training-docs/docs/module31-production-deployment-strategies/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 24: Production Deployment Strategies

--- a/adk-training-docs/docs/module32-deployment-cloud-run/lab-solution.md
+++ b/adk-training-docs/docs/module32-deployment-cloud-run/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 ## Module 32: Deployment to Cloud Run
 
 # Lab 32: Solution

--- a/adk-training-docs/docs/module32-deployment-cloud-run/lab.md
+++ b/adk-training-docs/docs/module32-deployment-cloud-run/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 25: Deployment to Cloud Run

--- a/adk-training-docs/docs/module33-deployment-gke/lab-solution.md
+++ b/adk-training-docs/docs/module33-deployment-gke/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 ## Module 33: Deployment to Google Kubernetes Engine (GKE)
 
 # Lab 33: Solution

--- a/adk-training-docs/docs/module33-deployment-gke/lab.md
+++ b/adk-training-docs/docs/module33-deployment-gke/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 26: Deployment to Google Kubernetes Engine (GKE)

--- a/adk-training-docs/docs/module34-deploying-mcp-server-cloud-run/lab-solution.md
+++ b/adk-training-docs/docs/module34-deploying-mcp-server-cloud-run/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 ## Module 34: Deploying an MCP Server to Cloud Run
 
 # Lab 34: Solution

--- a/adk-training-docs/docs/module34-deploying-mcp-server-cloud-run/lab.md
+++ b/adk-training-docs/docs/module34-deploying-mcp-server-cloud-run/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 31: Deploying an MCP Server to Cloud Run

--- a/adk-training-docs/docs/module35-deployment-agent-engine/lab-solution.md
+++ b/adk-training-docs/docs/module35-deployment-agent-engine/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 ## Module 35: Deploying to Agent Engine
 
 # Lab 35: Solution

--- a/adk-training-docs/docs/module35-deployment-agent-engine/lab.md
+++ b/adk-training-docs/docs/module35-deployment-agent-engine/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 34: Deploying to Agent Engine

--- a/adk-training-docs/docs/module36-gemini-enterprise/lab-solution.md
+++ b/adk-training-docs/docs/module36-gemini-enterprise/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 ## Module 36: Gemini Enterprise
 
 # Lab 36: Solution

--- a/adk-training-docs/docs/module36-gemini-enterprise/lab.md
+++ b/adk-training-docs/docs/module36-gemini-enterprise/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 37: Gemini Enterprise

--- a/adk-training-docs/docs/module37-advanced-personalized-shopping-agent/lab-solution.md
+++ b/adk-training-docs/docs/module37-advanced-personalized-shopping-agent/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 # Module 37: Advanced - Building a Personalized Shopping Agent
 
 # Lab 37: Solution

--- a/adk-training-docs/docs/module37-advanced-personalized-shopping-agent/lab.md
+++ b/adk-training-docs/docs/module37-advanced-personalized-shopping-agent/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 37: Advanced - Building a Personalized Shopping Agent

--- a/adk-training-docs/docs/module38-best-practices/lab-solution.md
+++ b/adk-training-docs/docs/module38-best-practices/lab-solution.md
@@ -1,4 +1,5 @@
 ---
+---
 ## Module 38: Best Practices # Module 36: Best Practices & Production Patterns Production Patterns
 
 # Lab 38: Solution

--- a/adk-training-docs/docs/module38-best-practices/lab.md
+++ b/adk-training-docs/docs/module38-best-practices/lab.md
@@ -1,3 +1,4 @@
+---
 sidebar_position: 2
 ---
 # Module 36: Best Practices & Production Patterns


### PR DESCRIPTION
This commit restores the '---' front matter to all lab.md and lab-solution.md files across all modules. The front matter was inadvertently removed during a previous title correction, and this change ensures all files are correctly processed by Docusaurus.