### PR TITLE
fix(readme): correct module links to point to training source

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,68 +30,68 @@ The course is divided into several parts, each containing a set of modules. Each
 ### 🌱 Part 1: Foundations (Modules 1-7)
 This part covers the absolute basics of AI agents and the ADK, getting your environment set up and guiding you through building and running your first agents, including multimodal capabilities.
 
-*   📖 **[Module 1: Introduction to AI Agents & Google ADK](./adk-training-docs/docs/module01-intro-to-ai-agents/)**
-*   📖 **[Module 2: Setting Up Your Development Environment](./adk-training-docs/docs/module02-environment-setup/)**
-*   📖 **[Module 3: Your First Agent: The "Echo" Agent](./adk-training-docs/docs/module03-first-agent-echo/)**
-*   📖 **[Module 4: Core Agent Concepts: `LlmAgent` Deep Dive](./adk-training-docs/docs/module04-llmagent-deep-dive/)**
-*   📖 **[Module 5: Running and Interacting with Agents](./adk-training-docs/docs/module05-running-agents/)**
-*   📖 **[Module 6: Running an Agent Programmatically](./adk-training-docs/docs/module06-programmatic-execution/)**
-*   📖 **[Module 7: Multimodal and Images 📸](./adk-training-docs/docs/module07-multimodal-and-images/)**
+*   📖 **[Module 1: Introduction to AI Agents & Google ADK](./training/module01-intro-to-ai-agents/)**
+*   📖 **[Module 2: Setting Up Your Development Environment](./training/module02-environment-setup/)**
+*   📖 **[Module 3: Your First Agent: The "Echo" Agent](./training/module03-first-agent-echo/)**
+*   📖 **[Module 4: Core Agent Concepts: `LlmAgent` Deep Dive](./training/module04-llmagent-deep-dive/)**
+*   📖 **[Module 5: Running and Interacting with Agents](./training/module05-running-agents/)**
+*   📖 **[Module 6: Running an Agent Programmatically](./training/module06-programmatic-execution/)**
+*   📖 **[Module 7: Multimodal and Images 📸](./training/module07-multimodal-and-images/)**
 
 ### 🛠️ Part 2: Tools & Capabilities (Modules 8-14)
 This part focuses on giving your agents "superpowers" by connecting them to tools, from built-in capabilities to custom functions and third-party libraries.
 
-*   🧰 **[Module 8: Introduction to Tools](./adk-training-docs/docs/module08-intro-to-tools/)**
-*   🧰 **[Module 9: Intro to Custom Function Tools](./adk-training-docs/docs/module09-intro-custom-function-tools/)**
-*   🧰 **[Module 10: Advanced Function Tools](./adk-training-docs/docs/module10-advanced-function-tools/)**
-*   🧰 **[Module 11: OpenAPI Tools](./adk-training-docs/docs/module11-openapi-tools/)**
-*   🧰 **[Module 12: Built-in Tools and Grounding](./adk-training-docs/docs/module12-built-in-tools-grounding/)**
-*   🧰 **[Module 13: Tool Context](./adk-training-docs/docs/module13-tool-context/)**
-*   🧰 **[Module 14: Third-Party Tools](./adk-training-docs/docs/module14-third-party-tools/)**
+*   🧰 **[Module 8: Introduction to Tools](./training/module08-intro-to-tools/)**
+*   🧰 **[Module 9: Intro to Custom Function Tools](./training/module09-intro-custom-function-tools/)**
+*   🧰 **[Module 10: Advanced Function Tools](./training/module10-advanced-function-tools/)**
+*   🧰 **[Module 11: OpenAPI Tools](./training/module11-openapi-tools/)**
+*   🧰 **[Module 12: Built-in Tools and Grounding](./training/module12-built-in-tools-grounding/)**
+*   🧰 **[Module 13: Tool Context](./training/module13-tool-context/)**
+*   🧰 **[Module 14: Third-Party Tools](./training/module14-third-party-tools/)**
 
 ### 🤖🤖 Part 3: Multi-Agent Systems (Modules 15-21)
 Learn how to go beyond single agents and build complex systems where multiple agents collaborate to solve complex problems, both locally and in a distributed fashion.
 
-*   🤝 **[Module 15: Introduction to Multi-Agent Systems](./adk-training-docs/docs/module15-intro-to-multi-agent-systems/)**
-*   🤝 **[Module 16: Coordinator Agent](./adk-training-docs/docs/module16-coordinator-agent/)**
-*   🤝 **[Module 17: Sequential Workflow Agents](./adk-training-docs/docs/module17-sequential-workflow-agents/)**
-*   🤝 **[Module 18: Parallel Workflow Agents](./adk-training-docs/docs/module18-parallel-workflow-agents/)**
-*   🤝 **[Module 19: Advanced Multi-Agent Architectures](./adk-training-docs/docs/module19-advanced-multi-agent-architectures/)**
-*   🤝 **[Module 20: Loop Agents](./adk-training-docs/docs/module20-loop-agents/)**
-*   🤝 **[Module 21: Agent-to-Agent Communication](./adk-training-docs/docs/module21-agent-to-agent/)**
+*   🤝 **[Module 15: Introduction to Multi-Agent Systems](./training/module15-intro-to-multi-agent-systems/)**
+*   🤝 **[Module 16: Coordinator Agent](./training/module16-coordinator-agent/)**
+*   🤝 **[Module 17: Sequential Workflow Agents](./training/module17-sequential-workflow-agents/)**
+*   🤝 **[Module 18: Parallel Workflow Agents](./training/module18-parallel-workflow-agents/)**
+*   🤝 **[Module 19: Advanced Multi-Agent Architectures](./training/module19-advanced-multi-agent-architectures/)**
+*   🤝 **[Module 20: Loop Agents](./training/module20-loop-agents/)**
+*   🤝 **[Module 21: Agent-to-Agent Communication](./training/module21-agent-to-agent/)**
 
 ### 🏭 Part 4: Production Readiness (Modules 22-26)
 This part covers the essential features for making your agents robust, observable, and reliable in a production environment.
 
-*   🧠 **[Module 22: State and Memory](./adk-training-docs/docs/module22-state-and-memory/)**
-*   📦 **[Module 23: Artifacts](./adk-training-docs/docs/module23-artifacts/)**
-*   🧪 **[Module 24: Evaluation](./adk-training-docs/docs/module24-evaluation/)**
-*   📊 **[Module 25: Observability](./adk-training-docs/docs/module25-observability/)**
-*   🛡️ **[Module 26: Callbacks](./adk-training-docs/docs/module26-callbacks/)**
+*   🧠 **[Module 22: State and Memory](./training/module22-state-and-memory/)**
+*   📦 **[Module 23: Artifacts](./training/module23-artifacts/)**
+*   🧪 **[Module 24: Evaluation](./training/module24-evaluation/)**
+*   📊 **[Module 25: Observability](./training/module25-observability/)**
+*   🛡️ **[Module 26: Callbacks](./training/module26-callbacks/)**
 
 ### 🔌 Part 5: Advanced Integrations & UI (Modules 27-30)
 This section covers advanced tooling with the Model Context Protocol (MCP) and strategies for integrating your agents with user interfaces.
 
-*   🔗 **[Module 27: Introduction to MCP](./adk-training-docs/docs/module27-intro-to-mcp/)**
-*   🔗 **[Module 28: Building MCP Tools](./adk-training-docs/docs/module28-building-mcp-tools/)**
-*   🖼️ **[Module 29: UI Integration Intro](./adk-training-docs/docs/module29-ui-integration-intro/)**
-*   🖼️ **[Module 30: Custom Streaming Client](./adk-training-docs/docs/module30-custom-streaming-client/)**
+*   🔗 **[Module 27: Introduction to MCP](./training/module27-intro-to-mcp/)**
+*   🔗 **[Module 28: Building MCP Tools](./training/module28-building-mcp-tools/)**
+*   🖼️ **[Module 29: UI Integration Intro](./training/module29-ui-integration-intro/)**
+*   🖼️ **[Module 30: Custom Streaming Client](./training/module30-custom-streaming-client/)**
 
 ### ☁️ Part 6: Deployment & Enterprise (Modules 31-36)
 Learn how to deploy your agents and their components to various scalable cloud environments, including enterprise-grade platforms.
 
-*   🚀 **[Module 31: Production Deployment Strategies](./adk-training-docs/docs/module31-production-deployment-strategies/)**
-*   🚀 **[Module 32: Deployment to Cloud Run](./adk-training-docs/docs/module32-deployment-cloud-run/)**
-*   🚀 **[Module 33: Deployment to GKE](./adk-training-docs/docs/module33-deployment-gke/)**
-*   🚀 **[Module 34: Deploying an MCP Server to Cloud Run](./adk-training-docs/docs/module34-deploying-mcp-server-cloud-run/)**
-*   🚀 **[Module 35: Deployment to Agent Engine](./adk-training-docs/docs/module35-deployment-agent-engine/)**
-*   🚀 **[Module 36: Gemini Enterprise](./adk-training-docs/docs/module36-gemini-enterprise/)**
+*   🚀 **[Module 31: Production Deployment Strategies](./training/module31-production-deployment-strategies/)**
+*   🚀 **[Module 32: Deployment to Cloud Run](./training/module32-deployment-cloud-run/)**
+*   🚀 **[Module 33: Deployment to GKE](./training/module33-deployment-gke/)**
+*   🚀 **[Module 34: Deploying an MCP Server to Cloud Run](./training/module34-deploying-mcp-server-cloud-run/)**
+*   🚀 **[Module 35: Deployment to Agent Engine](./training/module35-deployment-agent-engine/)**
+*   🚀 **[Module 36: Gemini Enterprise](./training/module36-gemini-enterprise/)**
 
 ### 🏆 Part 7: Capstone Project & Best Practices (Modules 37-38)
 Apply everything you've learned in a final capstone project and review the essential best practices for building production-ready agents.
 
-*   ✨ **[Module 37: Advanced Personalized Shopping Agent](./adk-training-docs/docs/module37-advanced-personalized-shopping-agent/)**
-*   ✨ **[Module 38: Best Practices](./adk-training-docs/docs/module38-best-practices/)**
+*   ✨ **[Module 37: Advanced Personalized Shopping Agent](./training/module37-advanced-personalized-shopping-agent/)**
+*   ✨ **[Module 38: Best Practices](./training/module38-best-practices/)**
 
 ---
 


### PR DESCRIPTION
This commit corrects the links in the main README.md file. The links to the course modules now point to the source of truth in the 'training/' directory, rather than the Docusaurus 'adk-training-docs/docs/' directory.