### PR TITLE
fix(docs): set correct baseUrl for github pages

### DIFF
--- a/doc/docusaurus.config.js
+++ b/doc/docusaurus.config.js
@@ -1,7 +1,7 @@
 const config = {
   title: 'ADK Training Docs',
   url: 'https://mauripsale.github.io',
-  baseUrl: '/',
+  baseUrl: '/doc-adk-training/',
   favicon: 'img/favicon.ico',
   onBrokenLinks: 'throw',
     markdown: {


### PR DESCRIPTION
This commit corrects the 'baseUrl' in 'docusaurus.config.js' to '/doc-adk-training/'. The previous value of '/' was incorrect for a GitHub Pages repository deployment, causing the site to fail to load its assets. This change aligns the configuration with the deployment URL.