### PR TITLE
fix(docs): escape env vars in module 33 lab to fix docusaurus build

### DIFF
--- a/training/module33-deployment-gke/lab.md
+++ b/training/module33-deployment-gke/lab.md
@@ -76,7 +76,7 @@ In this lab, you will learn the fundamental process of deploying an ADK agent to
 2.  **Build and Push with Cloud Build:**
     ```shell
     gcloud builds submit \
-        --tag ${GOOGLE_CLOUD_LOCATION}-docker.pkg.dev/${GOOGLE_CLOUD_PROJECT}/adk-images/echo-agent:v1
+        --tag \${GOOGLE_CLOUD_LOCATION}-docker.pkg.dev/\${GOOGLE_CLOUD_PROJECT}/adk-images/echo-agent:v1
     ```
 
 ### Step 4: Create and Deploy to a GKE Cluster
@@ -112,16 +112,16 @@ spec:
 spec:
   containers:
   - name: echo-agent
-    image: ${GOOGLE_CLOUD_LOCATION}-docker.pkg.dev/${GOOGLE_CLOUD_PROJECT}/adk-images/echo-agent:v1
+    image: \${GOOGLE_CLOUD_LOCATION}-docker.pkg.dev/\${GOOGLE_CLOUD_PROJECT}/adk-images/echo-agent:v1
     ports:
     - containerPort: 8080
     env:
       - name: GOOGLE_GENAI_USE_VERTEXAI
         value: "1"
       - name: GOOGLE_CLOUD_PROJECT
-        value: "${GOOGLE_CLOUD_PROJECT}"
+        value: "\${GOOGLE_CLOUD_PROJECT}"
       - name: GOOGLE_CLOUD_LOCATION
-        value: "${GOOGLE_CLOUD_LOCATION}"
+        value: "\${GOOGLE_CLOUD_LOCATION}"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Escaped '${GOOGLE_CLOUD_LOCATION}' and '${GOOGLE_CLOUD_PROJECT}' in YAML and Shell code blocks within 'training/module33-deployment-gke/lab.md'. MDX v2 was interpreting these as JavaScript variables, causing a 'ReferenceError' during the Docusaurus build process.