### PR TITLE
fix(docs): update internal links in workshop variants

### DIFF
--- a/variant-a-1-day-workshop.md
+++ b/variant-a-1-day-workshop.md
@@ -6,10 +6,10 @@ This workshop is a focused, high-impact training variant designed to provide a s
 
 | Module | Include? (YES/NO) | Justification for Inclusion/Exclusion |
 | :--- | :--- | :--- |
-| [Module 1: Introduction to AI Agents & Google ADK](/training/module01-intro-to-ai-agents/) | YES | Essential foundational theory on what agents are and why the ADK is used. |
-| [Module 2: Setting Up Your Development Environment](/training/module02-environment-setup/) | YES | Critical hands-on step; participants cannot proceed without a working environment. |
-| [Module 3: Your First Agent: The "Echo" Agent](/training/module03-first-agent-echo/) | YES | Core practical skill: building and running a basic agent. |
-| [Module 4: Core Agent Concepts: `LlmAgent` Deep Dive](/training/module04-llmagent-deep-dive/) | YES | Foundational skill: controlling agent behavior via instructions is non-negotiable. |
-| [Module 8: Introduction to Tools](/training/module08-intro-to-tools/) | YES | Core concept: introduces the most important feature for building capable agents. |
-| [Module 9: Intro to Custom Function Tools](/training/module09-intro-custom-function-tools/) | YES | The most critical hands-on lab for creating practical, real-world agents. (Time reduced to 50 min for workshop focus) |
-| [Module 27: Introduction to MCP](/training/module27-intro-to-mcp/) | YES | Provides a high-level overview of MCP, crucial for understanding advanced tool integration. (Overview only, 30 min) |
+| [Module 1: Introduction to AI Agents & Google ADK](/module01-intro-to-ai-agents/) | YES | Essential foundational theory on what agents are and why the ADK is used. |
+| [Module 2: Setting Up Your Development Environment](/module02-environment-setup/) | YES | Critical hands-on step; participants cannot proceed without a working environment. |
+| [Module 3: Your First Agent: The "Echo" Agent](/module03-first-agent-echo/) | YES | Core practical skill: building and running a basic agent. |
+| [Module 4: Core Agent Concepts: `LlmAgent` Deep Dive](/module04-llmagent-deep-dive/) | YES | Foundational skill: controlling agent behavior via instructions is non-negotiable. |
+| [Module 8: Introduction to Tools](/module08-intro-to-tools/) | YES | Core concept: introduces the most important feature for building capable agents. |
+| [Module 9: Intro to Custom Function Tools](/module09-intro-custom-function-tools/) | YES | The most critical hands-on lab for creating practical, real-world agents. (Time reduced to 50 min for workshop focus) |
+| [Module 27: Introduction to MCP](/module27-intro-to-mcp/) | YES | Provides a high-level overview of MCP, crucial for understanding advanced tool integration. (Overview only, 30 min) |

--- a/variant-b-2-day-ilt.md
+++ b/variant-b-2-day-ilt.md
@@ -6,17 +6,17 @@ This 2-day training variant provides a comprehensive learning experience that co
 
 | Module | Include? (YES/NO) | Justification for Inclusion/Exclusion |
 | :--- | :--- | :--- |
-| [Module 1: Introduction to AI Agents & Google ADK](/training/module01-intro-to-ai-agents/) | YES | Forms the foundational core of the 2-day workshop. |
-| [Module 2: Setting Up Your Development Environment](/training/module02-environment-setup/) | YES | Forms the foundational core of the 2-day workshop. |
-| [Module 3: Your First Agent: The "Echo" Agent](/training/module03-first-agent-echo/) | YES | Forms the foundational core of the 2-day workshop. |
-| [Module 4: Core Agent Concepts: `LlmAgent` Deep Dive](/training/module04-llmagent-deep-dive/) | YES | Forms the foundational core of the 2-day workshop. |
-| [Module 5: Running and Interacting with Agents](/training/module05-running-agents/) | YES | Key skill for developers to understand debugging and deployment previews. |
-| [Module 6: Running an Agent Programmatically](/training/module06-programmatic-execution/) | YES | Essential for any developer looking to integrate agents into actual applications. |
-| [Module 8: Introduction to Tools](/training/module08-intro-to-tools/) | YES | Forms the foundational core of the 2-day workshop. |
-| [Module 9: Intro to Custom Function Tools](/training/module09-intro-custom-function-tools/) | YES | Forms the foundational core of the 2-day workshop. |
-| [Module 10: Advanced Function Tools](/training/module10-advanced-function-tools/) | YES | Teaches crucial best practices and the important parallel execution feature. |
-| [Module 12: Built-in Tools and Grounding](/training/module12-built-in-tools-grounding/) | YES | Provides a key capability (web search) for building more knowledgeable agents. |
-| [Module 15: Introduction to Multi-Agent Systems](/training/module15-intro-to-multi-agent-systems/) | YES | Introduces the next level of agent design, a key differentiator of the ADK. |
-| [Module 16: Coordinator Agent](/training/module16-coordinator-agent/) | YES | A practical, hands-on lab for building a simple but powerful multi-agent system. |
-| [Module 22: State and Memory](/training/module22-state-and-memory/) | YES | Covers the essential topic of managing conversation history for better user experience. |
-| [Module 38: Best Practices](/training/module38-best-practices/) | YES | A crucial summary module to reinforce key learnings and guide future development. |
+| [Module 1: Introduction to AI Agents & Google ADK](/module01-intro-to-ai-agents/) | YES | Forms the foundational core of the 2-day workshop. |
+| [Module 2: Setting Up Your Development Environment](/module02-environment-setup/) | YES | Forms the foundational core of the 2-day workshop. |
+| [Module 3: Your First Agent: The "Echo" Agent](/module03-first-agent-echo/) | YES | Forms the foundational core of the 2-day workshop. |
+| [Module 4: Core Agent Concepts: `LlmAgent` Deep Dive](/module04-llmagent-deep-dive/) | YES | Forms the foundational core of the 2-day workshop. |
+| [Module 5: Running and Interacting with Agents](/module05-running-agents/) | YES | Key skill for developers to understand debugging and deployment previews. |
+| [Module 6: Running an Agent Programmatically](/module06-programmatic-execution/) | YES | Essential for any developer looking to integrate agents into actual applications. |
+| [Module 8: Introduction to Tools](/module08-intro-to-tools/) | YES | Forms the foundational core of the 2-day workshop. |
+| [Module 9: Intro to Custom Function Tools](/module09-intro-custom-function-tools/) | YES | Forms the foundational core of the 2-day workshop. |
+| [Module 10: Advanced Function Tools](/module10-advanced-function-tools/) | YES | Teaches crucial best practices and the important parallel execution feature. |
+| [Module 12: Built-in Tools and Grounding](/module12-built-in-tools-grounding/) | YES | Provides a key capability (web search) for building more knowledgeable agents. |
+| [Module 15: Introduction to Multi-Agent Systems](/module15-intro-to-multi-agent-systems/) | YES | Introduces the next level of agent design, a key differentiator of the ADK. |
+| [Module 16: Coordinator Agent](/module16-coordinator-agent/) | YES | A practical, hands-on lab for building a simple but powerful multi-agent system. |
+| [Module 22: State and Memory](/module22-state-and-memory/) | YES | Covers the essential topic of managing conversation history for better user experience. |
+| [Module 38: Best Practices](/module38-best-practices/) | YES | A crucial summary module to reinforce key learnings and guide future development. |


### PR DESCRIPTION
Removed '/training/' prefix from links in 'variant-a-1-day-workshop.md' and 'variant-b-2-day-ilt.md'. Docusaurus is configured with 'routeBasePath: /', so links should point directly to '/module...' instead of '/training/module...', resolving the broken link errors during build.