### PR TITLE
feat(docs): add github link to navbar

### DIFF
--- a/doc/docusaurus.config.js
+++ b/doc/docusaurus.config.js
@@ -22,6 +22,11 @@ const config = {
           label: 'Modules',
           position: 'left'
         },
+        {
+          href: 'https://github.com/mauripsale/doc-adk-training',
+          label: 'GitHub',
+          position: 'right',
+        },
       ],
     },
     footer: {


### PR DESCRIPTION
Added a 'GitHub' link to the right side of the Docusaurus navbar in 'docusaurus.config.js', pointing to the project repository (https://github.com/mauripsale/doc-adk-training).